### PR TITLE
Pin oniguruma to 5.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,14 @@ source:
   md5: 0933532b086bd8b6a41c1b162b1731f9
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
   build:
-    - oniguruma
+    - oniguruma 5.9.*
   run:
-    - oniguruma
+    - oniguruma 5.9.*
 
 test:
   commands:


### PR DESCRIPTION
Pins `oniguruma` to 5.9.x. This is being done as precautionary before building `oniguruma` version `6.0.0`.
